### PR TITLE
removed ipdb unused import

### DIFF
--- a/dfme/network/gan.py
+++ b/dfme/network/gan.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import ipdb
 
 class Flatten(nn.Module):
     def __init__(self):

--- a/dfme/train.py
+++ b/dfme/train.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import argparse, ipdb, json
+import argparse, json
 import torch
 import torch.nn.functional as F
 import torch.nn as nn

--- a/surrogate_benchmark/dataloader.py
+++ b/surrogate_benchmark/dataloader.py
@@ -1,7 +1,6 @@
 from torchvision import datasets, transforms
 from torch.utils.data import DataLoader, Dataset
 import PIL
-import ipdb
 import torch
 
 class RandDataset(Dataset):

--- a/surrogate_benchmark/train.py
+++ b/surrogate_benchmark/train.py
@@ -1,5 +1,4 @@
 import torch
-import ipdb
 import torch.nn as nn
 import torch.optim as optim
 import sys, os, json
@@ -38,7 +37,6 @@ def epoch(args, loader, model, teacher = None, lr_schedule = None, epoch_i = Non
     func = tqdm if stop == False else lambda x:x
     criterion_kl = nn.KLDivLoss(reduction = "batchmean")
     alpha, T = 1.0, args.temp
-    # ipdb.set_trace()
     for batch in func(loader):
         X,y = batch[0].to(args.device), batch[1].to(args.device)
         if args.surrogate == "mnist":


### PR DESCRIPTION
IPDB was imported but never used and it was causing `ImportError` during setup.
This commit removes the unused import.